### PR TITLE
don't overwrite systctl.conf,

### DIFF
--- a/playbooks/network.yml
+++ b/playbooks/network.yml
@@ -4,7 +4,7 @@
     ansible_ssh_host: "{{ mac|mac2ll }}%vtnet0"
   tasks:
     - name: write sysctl.conf to the disk
-      copy: src=../templates/network/sysctl.conf dest=/etc/sysctl.conf
+      copy: src=../templates/network/sysctl.conf dest=/etc/sysctl.d/99-disable-v6-ra-and-autoconf.conf
     - name: write resolv.conf to the disk
       copy: src=../templates/network/resolv.conf dest=/etc/resolv.conf
     - name: write /etc/network/interfaces


### PR DESCRIPTION
drop settings in sysctl.d folder as new file named 99-disable-v6-ra-and-autoconf.conf
